### PR TITLE
Fix error in Installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## Installation
  
 ```shell
-python -m venv .
+python -m venv pip
 
 .\pip\Scripts\activate
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@
 ## Installation
  
 ```shell
-python -m venv pip
+python -m venv .
 
 .\pip\Scripts\activate
 
-python install -r requirement.txt
+pip install -r requirement.txt
 
 yarn install
 ```


### PR DESCRIPTION
The command `python -m venv pip` will create a directory called `pip` and create an environment inside it. The correct command is `python -m venv .`, where the dot is the current path.

Another mistake is `python install -r requirement.txt` because python will search for a file called `install`, use pip to fix it.

edit: In Linux to represent the current path is used a dot. but I don't know if in windows the behavior is the same.